### PR TITLE
Adds Support for AWS Provider 4.9+

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_language_version:
     python: python3
 
 repos:
-  - repo: git://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0
     hooks:
       - id: check-json
@@ -17,7 +17,7 @@ repos:
         args:
           - --markdown-linebreak-ext=md
 
-  - repo: git://github.com/antonbabenko/pre-commit-terraform
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.43.0
     hooks:
       - id: terraform_fmt

--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ A Terraform module for enabling VPC Flow Logs to an S3 bucket.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.28 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0, != 4.0, != 4.1, != 4.2, != 4.3, != 4.4, != 4.5, != 4.6, != 4.7, != 4.8 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0, != 4.0, != 4.1, != 4.2, != 4.3, != 4.4, != 4.5, != 4.6, != 4.7, != 4.8 |
 
 ## Modules
 

--- a/examples/vpc-flowlogs/config.tf
+++ b/examples/vpc-flowlogs/config.tf
@@ -2,7 +2,7 @@
 # AWS Provider Settings       #
 #=============================#
 provider "aws" {
-  version                 = "~> 3.0"
+  version                 = ">= 3.0, != 4.0, != 4.1, != 4.2, != 4.3, != 4.4, != 4.5, != 4.6, != 4.7, != 4.8"
   region                  = var.region
   profile                 = var.profile
   shared_credentials_file = "~/.aws/bb/config"

--- a/versions.tf
+++ b/versions.tf
@@ -3,6 +3,6 @@ terraform {
   required_version = ">= 0.12.28"
 
   required_providers {
-    aws = "~> 3.0"
+    aws = ">= 3.0, != 4.0, != 4.1, != 4.2, != 4.3, != 4.4, != 4.5, != 4.6, != 4.7, != 4.8"
   }
 }


### PR DESCRIPTION
## what
* Adds support for AWS Provider 4.9+
* This version works fine with the current S3 setup

## why
* Some users need new features added by version 4 of the provider

## references
* https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-4-upgrade

