### PR TITLE
Improve policy management

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,16 +44,22 @@ No modules.
 |------|------|
 | [aws_flow_log.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/flow_log) | resource |
 | [aws_s3_bucket.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
-| [aws_s3_bucket_policy.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
+| [aws_s3_bucket_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_public_access_block.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_iam_policy_document.allow_vpc_flowlogs_delivery_service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.combined](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.ssl_enforce](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_bucket_name_prefix"></a> [bucket\_name\_prefix](#input\_bucket\_name\_prefix) | S3 Bucket Name Prefix | `string` | `"S3 Bucket for Terraform Remote State Storage"` | no |
+| <a name="input_custom_policy"></a> [custom\_policy](#input\_custom\_policy) | Custom policy | `string` | `null` | no |
+| <a name="input_enable_vpc_delivery_service"></a> [enable\_vpc\_delivery\_service](#input\_enable\_vpc\_delivery\_service) | Enable VPC delivery service policy | `bool` | `true` | no |
+| <a name="input_enforce_ssl"></a> [enforce\_ssl](#input\_enforce\_ssl) | Enforce bucket SSL encryption | `bool` | `true` | no |
 | <a name="input_force_destroy"></a> [force\_destroy](#input\_force\_destroy) | Whether to forcefully destroy the bucket or not | `bool` | `false` | no |
-| <a name="input_tags"></a> [tags](#input\_tags) | Tags To Apply To Created Resources | `map` | `{}` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Tags To Apply To Created Resources | `any` | `{}` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC ID | `string` | `""` | no |
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_bucket_name_prefix"></a> [bucket\_name\_prefix](#input\_bucket\_name\_prefix) | S3 Bucket Name Prefix | `string` | `"S3 Bucket for Terraform Remote State Storage"` | no |
 | <a name="input_custom_policy"></a> [custom\_policy](#input\_custom\_policy) | Custom policy | `string` | `null` | no |
+| <a name="input_enable_default_policy"></a> [enable\_default\_policy](#input\_enable\_default\_policy) | Enable default policy | `bool` | `true` | no |
 | <a name="input_enable_vpc_delivery_service"></a> [enable\_vpc\_delivery\_service](#input\_enable\_vpc\_delivery\_service) | Enable VPC delivery service policy | `bool` | `true` | no |
 | <a name="input_enforce_ssl"></a> [enforce\_ssl](#input\_enforce\_ssl) | Enforce bucket SSL encryption | `bool` | `true` | no |
 | <a name="input_force_destroy"></a> [force\_destroy](#input\_force\_destroy) | Whether to forcefully destroy the bucket or not | `bool` | `false` | no |

--- a/examples/vpc-flowlogs/main.tf
+++ b/examples/vpc-flowlogs/main.tf
@@ -32,4 +32,5 @@ module "vpc_flow_logs_test" {
   bucket_name_prefix = "${var.project}-${var.environment}"
   tags               = local.tags
   force_destroy      = true
+
 }

--- a/examples/vpc-flowlogs/outputs.tf
+++ b/examples/vpc-flowlogs/outputs.tf
@@ -8,3 +8,7 @@ output "flow_log_id" {
 output "bucket_arn" {
   value = module.vpc_flow_logs_test.bucket_arn
 }
+
+output "bucket_name" {
+  value = module.vpc_flow_logs_test.bucket_name
+}

--- a/examples/vpc-flowlogs/variables.tf
+++ b/examples/vpc-flowlogs/variables.tf
@@ -8,5 +8,5 @@ variable "project" {
 
 variable "environment" {
   description = "Environment Name"
-  default     = "dev-test"
+  default     = "apps-devstg-test"
 }

--- a/main.tf
+++ b/main.tf
@@ -117,11 +117,6 @@ data "aws_iam_policy_document" "allow_vpc_flowlogs_delivery_service" {
     sid = "AllowVpcFlowLogsDeliveryService"
 
     principals {
-      type        = "AWS"
-      identifiers = ["*"]
-    }
-
-    principals {
       type        = "Service"
       identifiers = ["delivery.logs.amazonaws.com"]
     }
@@ -137,7 +132,7 @@ data "aws_iam_policy_document" "allow_vpc_flowlogs_delivery_service" {
     ]
 
     condition {
-      test     = "StringEquals"
+      test     = "ForAnyValue:StringEquals"
       variable = "s3:x-amz-acl"
 
       values = [

--- a/main.tf
+++ b/main.tf
@@ -58,40 +58,88 @@ resource "aws_s3_bucket_public_access_block" "default" {
   restrict_public_buckets = true
 }
 
-resource "aws_s3_bucket_policy" "default" {
+# New
+resource "aws_s3_bucket_policy" "this" {
+  count = local.create_bucket && local.attach_policy ? 1 : 0
+
   bucket = aws_s3_bucket.this.id
-  policy = <<POLICY
-{
-  "Id": "TerraformStateBucketPolicies",
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "EnforceSSlRequestsOnly",
-      "Action": "s3:*",
-      "Effect": "Deny",
-      "Resource": "${aws_s3_bucket.this.arn}/*",
-      "Condition": {
-         "Bool": {
-           "aws:SecureTransport": "false"
-          }
-      },
-      "Principal": "*"
-    },
-    {
-      "Sid": "AllowVpcFlowLogsDeliveryService",
-      "Action": "s3:PutObject",
-      "Effect": "Allow",
-      "Resource": "${aws_s3_bucket.this.arn}/*",
-      "Condition": {
-         "StringEquals": {
-           "s3:x-amz-acl": "bucket-owner-full-control"
-          }
-      },
-      "Principal": {
-        "Service": "delivery.logs.amazonaws.com"
-      }
-    }
-  ]
+  policy = data.aws_iam_policy_document.combined[0].json
 }
-POLICY
+
+data "aws_iam_policy_document" "combined" {
+  count = local.create_bucket && local.attach_policy ? 1 : 0
+
+  source_policy_documents = compact([
+    var.enforce_ssl ? data.aws_iam_policy_document.ssl_enforce[0].json : "",
+    data.aws_iam_policy_document.allow_vpc_flowlogs_delivery_service.json,
+    var.custom_policy != null ? var.custom_policy : ""
+  ])
+}
+
+data "aws_iam_policy_document" "ssl_enforce" {
+  count = var.enforce_ssl ? 1 : 0
+
+  statement {
+    sid = "EnforceSSlRequestsOnly"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    effect = "Deny"
+
+    actions = [
+      "s3:*",
+    ]
+
+    resources = [
+      "${aws_s3_bucket.this.arn}/*",
+    ]
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+
+      values = [
+        "false",
+      ]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "allow_vpc_flowlogs_delivery_service" {
+
+  statement {
+    sid = "AllowVpcFlowLogsDeliveryService"
+
+    principals {
+      type        = "AWS"
+      identifiers = "*"
+    }
+
+    principals {
+      type        = "Service"
+      identifiers = ["delivery.logs.amazonaws.com"]
+    }
+
+    effect = "Allow"
+
+    actions = [
+      "s3:PutObject",
+    ]
+
+    resources = [
+      "${aws_s3_bucket.this.arn}/*",
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "s3:x-amz-acl"
+
+      values = [
+        "bucket-owner-full-control",
+      ]
+    }
+  }
 }

--- a/main.tf
+++ b/main.tf
@@ -118,7 +118,7 @@ data "aws_iam_policy_document" "allow_vpc_flowlogs_delivery_service" {
 
     principals {
       type        = "AWS"
-      identifiers = "*"
+      identifiers = ["*"]
     }
 
     principals {

--- a/main.tf
+++ b/main.tf
@@ -71,12 +71,13 @@ data "aws_iam_policy_document" "combined" {
 
   source_policy_documents = compact([
     var.enforce_ssl ? data.aws_iam_policy_document.ssl_enforce[0].json : "",
-    data.aws_iam_policy_document.allow_vpc_flowlogs_delivery_service.json,
+    var.enable_vpc_delivery_service ? data.aws_iam_policy_document.allow_vpc_flowlogs_delivery_service[0].json : "",
     var.custom_policy != null ? var.custom_policy : ""
   ])
 }
 
 data "aws_iam_policy_document" "ssl_enforce" {
+
   count = var.enforce_ssl ? 1 : 0
 
   statement {
@@ -109,6 +110,8 @@ data "aws_iam_policy_document" "ssl_enforce" {
 }
 
 data "aws_iam_policy_document" "allow_vpc_flowlogs_delivery_service" {
+
+  count = var.enable_vpc_delivery_service ? 1 : 0
 
   statement {
     sid = "AllowVpcFlowLogsDeliveryService"

--- a/main.tf
+++ b/main.tf
@@ -60,14 +60,14 @@ resource "aws_s3_bucket_public_access_block" "default" {
 
 # New
 resource "aws_s3_bucket_policy" "this" {
-  count = local.create_bucket && local.attach_policy ? 1 : 0
+  count = var.enable_default_policy ? 1 : 0
 
   bucket = aws_s3_bucket.this.id
   policy = data.aws_iam_policy_document.combined[0].json
 }
 
 data "aws_iam_policy_document" "combined" {
-  count = local.create_bucket && local.attach_policy ? 1 : 0
+  count = var.enable_default_policy ? 1 : 0
 
   source_policy_documents = compact([
     var.enforce_ssl ? data.aws_iam_policy_document.ssl_enforce[0].json : "",

--- a/tests/verify_output_test.go
+++ b/tests/verify_output_test.go
@@ -8,8 +8,8 @@ import (
 )
 
 func TestAwsVpcFlowLogs(t *testing.T) {
-    expectedValue1  := "arn:aws:s3:::bb-dev-test-vpc-flowlogs"
-    expectedValue2  := "bb-dev-test-vpc-flowlogs"
+    expectedValue1  := "arn:aws:s3:::bb-apps-devstg-test-vpc-flowlogs"
+    expectedValue2  := "bb-apps-devstg-test-vpc-flowlogs"
 
     terraformOptions := &terraform.Options {
         // The path to where our Terraform code is located

--- a/variables.tf
+++ b/variables.tf
@@ -39,3 +39,9 @@ variable "custom_policy" {
   type        = string
   default     = null
 }
+
+variable "enable_default_policy" {
+  description = "Enable default policy"
+  type        = bool
+  default     = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -28,6 +28,12 @@ variable "enforce_ssl" {
   default     = true
 }
 
+variable "enable_vpc_delivery_service" {
+  description = "Enable VPC delivery service policy"
+  type        = bool
+  default     = true
+}
+
 variable "custom_policy" {
   description = "Custom policy"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -1,19 +1,35 @@
 variable "vpc_id" {
   description = "VPC ID"
+  type        = string
   default     = ""
 }
 
 variable "bucket_name_prefix" {
   description = "S3 Bucket Name Prefix"
+  type        = string
   default     = "S3 Bucket for Terraform Remote State Storage"
 }
 
 variable "tags" {
   description = "Tags To Apply To Created Resources"
+  type        = any
   default     = {}
 }
 
 variable "force_destroy" {
   description = "Whether to forcefully destroy the bucket or not"
+  type        = bool
   default     = false
+}
+
+variable "enforce_ssl" {
+  description = "Enforce bucket SSL encryption"
+  type        = bool
+  default     = true
+}
+
+variable "custom_policy" {
+  description = "Custom policy"
+  type        = string
+  default     = null
 }


### PR DESCRIPTION

## what
* Add support for enforceSSL policy
* Add support to deactivate the default policy (vpc flowlogs delivery service)
* Add support to add extra policies to be merged with the one configurable through the module

## why
*  Setting policy outside the module keeps the policy changing and Terraform complains about external changes. 


