### PR TITLE
Versioning bucket variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ No modules.
 | <a name="input_bucket_name_prefix"></a> [bucket\_name\_prefix](#input\_bucket\_name\_prefix) | S3 Bucket Name Prefix | `string` | `"S3 Bucket for Terraform Remote State Storage"` | no |
 | <a name="input_custom_policy"></a> [custom\_policy](#input\_custom\_policy) | Custom policy | `string` | `null` | no |
 | <a name="input_enable_default_policy"></a> [enable\_default\_policy](#input\_enable\_default\_policy) | Enable default policy | `bool` | `true` | no |
+| <a name="input_enable_versioning"></a> [enable\_versioning](#input\_enable\_versioning) | Enable bucket versioning | `bool` | `false` | no |
 | <a name="input_enable_vpc_delivery_service"></a> [enable\_vpc\_delivery\_service](#input\_enable\_vpc\_delivery\_service) | Enable VPC delivery service policy | `bool` | `true` | no |
 | <a name="input_enforce_ssl"></a> [enforce\_ssl](#input\_enforce\_ssl) | Enforce bucket SSL encryption | `bool` | `true` | no |
 | <a name="input_force_destroy"></a> [force\_destroy](#input\_force\_destroy) | Whether to forcefully destroy the bucket or not | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,7 @@ resource "aws_s3_bucket" "this" {
 
   # Versioning will not be needed for this
   versioning {
-    enabled = false
+    enabled = var.enable_versioning
   }
 
   # Enable encryption at rest

--- a/variables.tf
+++ b/variables.tf
@@ -45,3 +45,9 @@ variable "enable_default_policy" {
   type        = bool
   default     = true
 }
+
+variable "enable_versioning" {
+  description = "Enable bucket versioning"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
## what
Add a `enable_versioning` variable that will enable versioning on the bucket.

## why
Some clients may want to have versioning enable on all their buckets (because of security concerns).
