### PR TITLE
Fix S3 deprecation warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ No modules.
 | <a name="input_bucket_name_prefix"></a> [bucket\_name\_prefix](#input\_bucket\_name\_prefix) | S3 Bucket Name Prefix | `string` | `"S3 Bucket for Terraform Remote State Storage"` | no |
 | <a name="input_custom_policy"></a> [custom\_policy](#input\_custom\_policy) | Custom policy | `string` | `null` | no |
 | <a name="input_enable_default_policy"></a> [enable\_default\_policy](#input\_enable\_default\_policy) | Enable default policy | `bool` | `true` | no |
-| <a name="input_enable_versioning"></a> [enable\_versioning](#input\_enable\_versioning) | Enable bucket versioning | `bool` | `false` | no |
+| <a name="input_enable_versioning"></a> [enable\_versioning](#input\_enable\_versioning) | Enable bucket versioning | `string` | `Disabled` | no |
 | <a name="input_enable_vpc_delivery_service"></a> [enable\_vpc\_delivery\_service](#input\_enable\_vpc\_delivery\_service) | Enable VPC delivery service policy | `bool` | `true` | no |
 | <a name="input_enforce_ssl"></a> [enforce\_ssl](#input\_enforce\_ssl) | Enforce bucket SSL encryption | `bool` | `true` | no |
 | <a name="input_force_destroy"></a> [force\_destroy](#input\_force\_destroy) | Whether to forcefully destroy the bucket or not | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -20,12 +20,12 @@ resource "aws_s3_bucket" "this" {
   force_destroy = var.force_destroy
 }
 
-resource "aws_s3_bucket_acl" "acl" {
+resource "aws_s3_bucket_acl" "default" {
   bucket = aws_s3_bucket.this.id
   acl    = "private"
 }
 # Versioning will not be needed for this
-resource "aws_s3_bucket_versioning" "versioning" {
+resource "aws_s3_bucket_versioning" "default" {
   bucket = aws_s3_bucket.this.id
   versioning_configuration {
     status = var.enable_versioning
@@ -33,7 +33,7 @@ resource "aws_s3_bucket_versioning" "versioning" {
 }
 
 # Enable encryption at rest
-resource "aws_s3_bucket_server_side_encryption_configuration" "encryption_config" {
+resource "aws_s3_bucket_server_side_encryption_configuration" "default" {
   bucket = aws_s3_bucket.this.id
   rule {
     apply_server_side_encryption_by_default {
@@ -45,7 +45,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "encryption_config
 # Enable lifecycle:
 #   - After 30 days, data is moved to Standard Infrequent Access
 #   - After 60 days, data is expired
-resource "aws_s3_bucket_lifecycle_configuration" "lifecycle_config" {
+resource "aws_s3_bucket_lifecycle_configuration" "default" {
   bucket = aws_s3_bucket.this.id
   rule {
     id     = "vpc-flow-log-rule-1"

--- a/main.tf
+++ b/main.tf
@@ -37,7 +37,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "default" {
   bucket = aws_s3_bucket.this.id
   rule {
     apply_server_side_encryption_by_default {
-      sse_algorithm = "AES256"
+      sse_algorithm = var.sse_algorithm
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -61,3 +61,13 @@ variable "enable_versioning" {
     error_message = "Wrong state. Available only: Enabled, Disabled or Suspended"
   }
 }
+
+variable "sse_algorithm" {
+  description = "Server-side encryption algorythm"
+  type        = string
+  default     = "AES256"
+  validation {
+    condition     = can(regex("^(AES256|aws:kms)$", var.sse_algorithm))
+    error_message = "Wrong SSE algorythm. Available only: AES256 or aws:kms"
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -54,6 +54,10 @@ variable "enable_default_policy" {
 
 variable "enable_versioning" {
   description = "Enable bucket versioning"
-  type        = bool
-  default     = false
+  type        = string
+  default     = "Disabled"
+  validation {
+    condition     = can(regex("^(Enabled|Disabled|Suspended)$", var.enable_versioning))
+    error_message = "Wrong state. Available only: Enabled, Disabled or Suspended"
+  }
 }


### PR DESCRIPTION
## what
Fixed AWS S3 Terraform provider deprecation warnings for some parameters. Some of them are a separate resources now.

## why
For further compatibility

## references
Deprecation notices at https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#argument-reference

